### PR TITLE
Update timer durations

### DIFF
--- a/app/src/main/java/jp/hiroshi/nov/m/a7minuteworkout/ExerciseActivity.kt
+++ b/app/src/main/java/jp/hiroshi/nov/m/a7minuteworkout/ExerciseActivity.kt
@@ -21,11 +21,11 @@ class ExerciseActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
 
     private var restTimer: CountDownTimer? = null
     private var restProgress = 0
-    private var restTimerDuration: Long = 1
+    private var restTimerDuration: Long = 10
     private var exerciseTimer: CountDownTimer? = null
     private var exerciseProgress = 0
 
-    private var exerciseTimerDuration: Long = 1
+    private var exerciseTimerDuration: Long = 30
 
     private var exerciseList: ArrayList<ExerciseModel>? = null
     private var currentExercisePosition = -1
@@ -94,8 +94,8 @@ class ExerciseActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         restTimer = object : CountDownTimer(restTimerDuration * 1000, 1000) {
             override fun onTick(p0: Long) {
                 restProgress++
-                progressBar.progress = 10 - restProgress
-                tvTimer.text = (10 - restProgress).toString()
+                progressBar.progress = restTimerDuration.toInt() - restProgress
+                tvTimer.text = (restTimerDuration.toInt() - restProgress).toString()
             }
 
             override fun onFinish() {


### PR DESCRIPTION
## Summary
- set rest duration to 10 seconds and exercise duration to 30 seconds
- keep progress bar math synced with the new durations

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d04a2576c832b9e48a7180e6c6246