### PR TITLE
Fix typo in custom back confirmation dialog

### DIFF
--- a/app/src/main/res/layout/dialog_custom_back_confirmation.xml
+++ b/app/src/main/res/layout/dialog_custom_back_confirmation.xml
@@ -22,7 +22,7 @@
         android:layout_marginTop="10dp"
         android:layout_marginEnd="10dp"
         android:gravity="center"
-        android:text="This will stop your workout. You\'ve come this faar, are you sure you want to quit?"
+        android:text="This will stop your workout. You\'ve come this far, are you sure you want to quit?"
         android:textColor="#212121"
         android:textSize="16sp"/>
 


### PR DESCRIPTION
## Summary
- fix a typo in the quit confirmation dialog

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684d049d7bc0832b98c5de856b43513a