### PR TITLE
Add unit test for Constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,8 @@ Androidアプリ「7 Minute Workout」のサンプルプロジェクトです。
 |— build.gradle     プロジェクト全体の設定
 |— settings.gradle  モジュール管理
 ```
+
+## テスト
+単体テストは `app/src/test/java` に配置されています。
+最近追加された `ConstantsTest.kt` では、 `Constants.defaultExerciseList()` が
+12 個のエクササイズを返すこと、また最初の要素が "JumpingJacks" であることを確認しています。

--- a/app/src/test/java/jp/hiroshi/nov/m/a7minuteworkout/ConstantsTest.kt
+++ b/app/src/test/java/jp/hiroshi/nov/m/a7minuteworkout/ConstantsTest.kt
@@ -1,0 +1,13 @@
+package jp.hiroshi.nov.m.a7minuteworkout
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConstantsTest {
+    @Test
+    fun defaultExerciseList_returnsFullList() {
+        val exerciseList = Constants.defaultExerciseList()
+        assertEquals(12, exerciseList.size)
+        assertEquals("JumpingJacks", exerciseList[0].getName())
+    }
+}


### PR DESCRIPTION
## Summary
- test that `Constants.defaultExerciseList()` provides 12 exercises
- verify that the first exercise is named *JumpingJacks*
- document the new `ConstantsTest.kt`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle)*

------
https://chatgpt.com/codex/tasks/task_e_684d048c2ed4832bb11769330ed21cc7